### PR TITLE
2.12, fix mistake, update label to match release

### DIFF
--- a/Colorizer/Form1.Designer.cs
+++ b/Colorizer/Form1.Designer.cs
@@ -98,10 +98,10 @@
             this.label2.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
             this.label2.Location = new System.Drawing.Point(12, 206);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(347, 26);
+            this.label2.Size = new System.Drawing.Size(350, 26);
             this.label2.TabIndex = 6;
-            this.label2.Text = "Thanks to cFLean, Sheldon and NWPlayer for help\r\nNote: This tool disables online " +
-    "until restart because Nintendo can detect it";
+            this.label2.Text = "Thanks to Nefarious, cFLean, Sheldon and NWPlayer for help.\r\nNote: This tool disa" +
+    "bles online until restart because Nintendo can detect it.";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // SettingsGroupBox
@@ -237,7 +237,7 @@
             this.MaximizeBox = false;
             this.Name = "MainForm";
             this.ShowIcon = false;
-            this.Text = "Colorizer";
+            this.Text = "Colorizer - Splatoon 2.12.0";
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             this.SettingsGroupBox.ResumeLayout(false);

--- a/Colorizer/Form1.cs
+++ b/Colorizer/Form1.cs
@@ -532,15 +532,26 @@ namespace Colorizer
                 return;
             }
 
-            //disables online because Nintendo detects color changing
-            Gecko.poke(0x1061483C + diff, 0x5F476573);
-            Gecko.poke(0x10614844 + diff, 0x756C6174);
-            Gecko.poke(0x10614858 + diff, 0x68650000);
-            Gecko.poke(0x10614890 + diff, 0x63650000);
-            Gecko.poke(0x10614880 + diff, 0x73656372);
-            Gecko.poke(0x10614874 + diff, 0x65742074);
-            Gecko.poke(0x12AEF24C + diff, 0x65787421);
-            Gecko.poke(0x12B4D45C + diff, 0xDEADCAFE);
+            //check for "_Fes" indicating the offsets used by the online disabler haven't moved
+            if (Gecko.peek(0x1061484C) == 0x5F466573)
+            {
+                //disables online because Nintendo detects color changing
+                Gecko.poke(0x1061484C, 0x5F476573);
+                Gecko.poke(0x10614854, 0x756C6174);
+                Gecko.poke(0x10614868, 0x68650000);
+                Gecko.poke(0x106148A0, 0x63650000);
+                Gecko.poke(0x10614890, 0x73656372);
+                Gecko.poke(0x10614884, 0x65742074);
+                Gecko.poke(0x12AEF24C + diff, 0x65787421);
+                Gecko.poke(0x12B4D45C + diff, 0xDEADCAFE);
+            }
+            else
+            {
+                MessageBox.Show("This ColorizerDotNet version isn't compatible with your Splatoon version. Check to see if there is a new ColorizerDotNet version available.");
+
+                Gecko.Disconnect();
+                return;
+            }
 
             SettingsGroupBox.Enabled = true;
             DisconnButton.Enabled = true;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ColorizerDotNet
 A (non-java) version of Splatoon Colorizer.
 
-Currently supported versions: 2.11(EU,US,JP).
+Currently supported versions: 2.12(EU,US,JP).
 Do not use this online, previous versions have shown that Nintendo can detect it.
 
 Thanks to cFLean, Sheldon, NWPlayer and OatmealDome for help and some useful functions.


### PR DESCRIPTION
Updated online disabler offsets for 2.12, fixed mistake I made when improving disabler, made it disconnect if the disabler isn't compatible, added compatible Splatoon version to title, updated the label to match release 1.2, and updated the supported versions text in README.